### PR TITLE
Timeout new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .span.iml
 span.iml
 .vscode/settings.json
+src/test/.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>com.americanexpress.span</groupId>
     <artifactId>span</artifactId>
     <packaging>jar</packaging>
-    <version>1.3.1</version>
+    <version>1.4.0</version>
     <name>span</name>
     <url>http://maven.apache.org</url>
 
@@ -125,7 +125,7 @@
     <properties>
         <junit.version>4.12</junit.version>
         <powermock.version>1.6.6</powermock.version>
-        <commons.version>2.6.0</commons.version>
+        <commons.version>2.9.0</commons.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <logback.version>1.2.3</logback.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/src/main/java/com/americanexpress/span/core/database/connection/SPANDataSource.java
+++ b/src/main/java/com/americanexpress/span/core/database/connection/SPANDataSource.java
@@ -145,6 +145,9 @@ public class SPANDataSource {
         basicDataSource.setRemoveAbandonedOnBorrow(true);
         basicDataSource.setRemoveAbandonedOnMaintenance(true);
         basicDataSource.addConnectionProperty("checkConnectionWhileIdle", String.valueOf(true));
+        if (Objects.nonNull(dataSourceDetails.getConnectionProperties())) {
+            dataSourceDetails.getConnectionProperties().forEach((k,v) -> basicDataSource.addConnectionProperty(k,v));
+        }
 
         return basicDataSource;
     }

--- a/src/main/java/com/americanexpress/span/models/DataSourceDetails.java
+++ b/src/main/java/com/americanexpress/span/models/DataSourceDetails.java
@@ -13,6 +13,8 @@
  */
 package com.americanexpress.span.models;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -64,6 +66,14 @@ public class DataSourceDetails {
 
     @JsonProperty("driverClassName")
     private String driverClassName;
+
+     /**
+     * The connection properties that will be sent to our JDBC driver when establishing new connections.
+     * <strong>NOTE</strong> - The "user" and "password" properties will be passed explicitly, so they do not need to be
+     * included here.
+     */
+    @JsonProperty("connectionProperties")
+    private Map<String,String> connectionProperties ;
 
     public String getDriverClassName() {
         return driverClassName;
@@ -185,6 +195,22 @@ public class DataSourceDetails {
 
     public void setTimeBetweenEvictionRunsMillis(int timeBetweenEvictionRunsMillis) {
         this.timeBetweenEvictionRunsMillis = timeBetweenEvictionRunsMillis;
+    }
+
+    /**
+     * Adds a custom connection property to the set that will be passed to our JDBC driver. This <strong>MUST</strong>
+     * be called before the first connection is retrieved (along with all the other configuration property setters).
+     * Calls to this method after the connection pool has been initialized have no effect.
+     *
+     * @param name  Name of the custom connection property
+     * @param value Value of the custom connection property
+     */
+    public void setConnectionProperties(Map<String,String> connectionProperties) {
+        this.connectionProperties = connectionProperties;
+    }
+
+    public Map<String,String> getConnectionProperties() {
+        return connectionProperties;
     }
 
     @Override

--- a/src/test/java/com/americanexpress/span/core/SPANConfigHolderTest.java
+++ b/src/test/java/com/americanexpress/span/core/SPANConfigHolderTest.java
@@ -46,6 +46,7 @@ public class SPANConfigHolderTest {
         assertEquals(2,spanConfig.getSpanUserDefineKeys().get("SPAN-DB_ID_1").getSpUserDefineKeys().size());
         assertEquals("PROC_NAME_1",spanConfig.getSpanUserDefineKeys().get("SPAN-DB_ID_1").getSpUserDefineKeys().get("PROC_ID_4").getProcedure());
         assertNotNull(spanConfig.toString());
+        assertEquals(1, spanConfig.getSpanUserDefineKeys().get("SPAN-DB_ID_1").getDataSourceDetails().getConnectionProperties().size());
     }
 
     @Test

--- a/src/test/resources/SPANConfig.yaml
+++ b/src/test/resources/SPANConfig.yaml
@@ -21,6 +21,8 @@ SPANConfig:
         database: "DB1"
         user: "test123"
         password: "pass123"
+        connectionProperties:
+          blockingReadConnectionTimeout: 5
       sp_details:
         PROC_ID_4:
           schema: "SCHEMA_ID"


### PR DESCRIPTION
1. Add `connectionProperties' field which accept Key and Value in the String. The values of this field will be passing to Database. Please see Database documentation what are the properties can be pass. For the DB2 case, DB2 requires to pass some additional timeout properties - https://rolf-engelhard.de/2015/08/timeout-configuration-in-hikaricp-db2-and-mysql/